### PR TITLE
ユーザー作成処理実装

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.14
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/go-sql-driver/mysql v1.5.0
+	github.com/google/uuid v1.1.2
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/valyala/fasttemplate v1.2.1 // indirect
-	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee // indirect
+	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v1.0.2 h1:KPldsxuKGsS2FPWsNeg9ZO18aCrGKujPoWXn2yo+KQM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/labstack/echo v1.4.4 h1:1bEiBNeGSUKxcPDGfZ/7IgdhJJZx8wV/pICJh4W2NJI=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
@@ -12,6 +16,8 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -1,0 +1,8 @@
+package constant
+
+const (
+	// MinNameLength ニックネームの最小文字数
+	MinNameLength = 2
+	// MaxNameLength ニックネームの最大文字数
+	MaxNameLength = 10
+)

--- a/pkg/domain/model/user/model.go
+++ b/pkg/domain/model/user/model.go
@@ -1,0 +1,8 @@
+package user
+
+// User Userを表すドメインモデル
+type User struct {
+	ID        string `json:"id"`
+	AuthToken string `json:"auth_token"`
+	Name      string `json:"name"`
+}

--- a/pkg/domain/repository/db/user/repository.go
+++ b/pkg/domain/repository/db/user/repository.go
@@ -1,0 +1,6 @@
+package user
+
+// Repository データ永続化のために抽象化したUserデータ更新周りの処理
+type Repository interface {
+	Create(ID, authToken, name string) error
+}

--- a/pkg/infrastructure/mysql/conn.go
+++ b/pkg/infrastructure/mysql/conn.go
@@ -16,15 +16,10 @@ const driverName = "mysql"
 var Conn *sql.DB
 
 func init() {
-	// ユーザ
 	user := os.Getenv("MYSQL_USER")
-	// パスワード
 	password := os.Getenv("MYSQL_PASSWORD")
-	// 接続先ホスト
 	host := os.Getenv("MYSQL_HOST")
-	// 接続先ポート
 	port := os.Getenv("MYSQL_PORT")
-	// 接続先データベース
 	database := os.Getenv("MYSQL_DATABASE")
 
 	var err error

--- a/pkg/infrastructure/mysql/conn.go
+++ b/pkg/infrastructure/mysql/conn.go
@@ -1,0 +1,36 @@
+package mysql
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	// blank import for MySQL driver
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const driverName = "mysql"
+
+// Conn 各repositoryで利用するDB接続(Connection)情報
+var Conn *sql.DB
+
+func init() {
+	// ユーザ
+	user := os.Getenv("MYSQL_USER")
+	// パスワード
+	password := os.Getenv("MYSQL_PASSWORD")
+	// 接続先ホスト
+	host := os.Getenv("MYSQL_HOST")
+	// 接続先ポート
+	port := os.Getenv("MYSQL_PORT")
+	// 接続先データベース
+	database := os.Getenv("MYSQL_DATABASE")
+
+	var err error
+	Conn, err = sql.Open(driverName,
+		fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, host, port, database))
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/infrastructure/mysql/repositoryimpl/user/repositoryimpl.go
+++ b/pkg/infrastructure/mysql/repositoryimpl/user/repositoryimpl.go
@@ -1,0 +1,28 @@
+package user
+
+import (
+	"database/sql"
+	ur "layered-arch-sample/pkg/domain/repository/db/user"
+)
+
+type repositoryImpl struct {
+	db *sql.DB
+}
+
+// NewRepositoryImpl Userに関するDB更新処理を生成
+func NewRepositoryImpl(db *sql.DB) ur.Repository {
+	return &repositoryImpl{
+		db,
+	}
+}
+
+// Create ユーザ登録処理
+func (uri repositoryImpl) Create(ID, authToken, name string) error {
+	stmt, err := uri.db.Prepare("INSERT INTO users (id, auth_token, name) VALUES (?, ?, ?)")
+	if err != nil {
+		return err
+	}
+
+	_, err = stmt.Exec(ID, authToken, name)
+	return err
+}

--- a/pkg/interfaces/api/handler/user/handler.go
+++ b/pkg/interfaces/api/handler/user/handler.go
@@ -1,0 +1,55 @@
+package user
+
+import (
+	"fmt"
+	"layered-arch-sample/pkg/constant"
+	um "layered-arch-sample/pkg/domain/model/user"
+	"layered-arch-sample/pkg/interfaces/api/myerror"
+	"layered-arch-sample/pkg/usecase/user"
+	"net/http"
+
+	"github.com/labstack/echo"
+	"github.com/pkg/errors"
+)
+
+// Handler UserにおけるHandlerのインターフェース
+type Handler interface {
+	HandleCreate(c echo.Context) error
+}
+
+type handler struct {
+	useCase user.UseCase
+}
+
+// NewHandler Userデータに関するHandlerを生成
+func NewHandler(uu user.UseCase) Handler {
+	return &handler{
+		useCase: uu,
+	}
+}
+
+// HandleCreate ユーザを作成するHandler
+func (uh handler) HandleCreate(c echo.Context) error {
+	type response struct {
+		Token string `json:"token"`
+	}
+
+	requestBody := new(um.User)
+	if err := c.Bind(requestBody); err != nil {
+		return &myerror.InternalServerError{Err: err}
+	}
+
+	if len(requestBody.Name) < constant.MinNameLength || constant.MaxNameLength < len(requestBody.Name) {
+		return &myerror.BadRequestError{
+			Err:     errors.Errorf(`query "name" is invalid: name="%s"`, requestBody.Name),
+			Message: fmt.Sprintf(`ユーザー名は2文字以上10文字以下に設定してください。(name: "%s")`, requestBody.Name),
+		}
+	}
+
+	authToken, err := uh.useCase.Create(requestBody.Name)
+	if err != nil {
+		return &myerror.InternalServerError{Err: err}
+	}
+
+	return c.JSON(http.StatusOK, &response{Token: authToken})
+}

--- a/pkg/interfaces/api/handler/user/handler.go
+++ b/pkg/interfaces/api/handler/user/handler.go
@@ -5,7 +5,7 @@ import (
 	"layered-arch-sample/pkg/constant"
 	um "layered-arch-sample/pkg/domain/model/user"
 	"layered-arch-sample/pkg/interfaces/api/myerror"
-	"layered-arch-sample/pkg/usecase/user"
+	uu "layered-arch-sample/pkg/usecase/user"
 	"net/http"
 
 	"github.com/labstack/echo"
@@ -18,13 +18,13 @@ type Handler interface {
 }
 
 type handler struct {
-	useCase user.UseCase
+	useCase uu.UseCase
 }
 
 // NewHandler Userデータに関するHandlerを生成
-func NewHandler(uu user.UseCase) Handler {
+func NewHandler(userUseCase uu.UseCase) Handler {
 	return &handler{
-		useCase: uu,
+		useCase: userUseCase,
 	}
 }
 

--- a/pkg/interfaces/api/myerror/myerror.go
+++ b/pkg/interfaces/api/myerror/myerror.go
@@ -1,0 +1,38 @@
+package myerror
+
+// BadRequestError 400:BadRequestエラー
+type BadRequestError struct {
+	Message string
+	Err     error
+}
+
+func (e *BadRequestError) Error() string {
+	return "Bad Request Error"
+}
+
+// UnauthorizedError 401:Unauthorizedエラー
+type UnauthorizedError struct {
+	Err error
+}
+
+func (e *UnauthorizedError) Error() string {
+	return "Unauthorized Error"
+}
+
+// NotFoundError 404:NotFoundエラー
+type NotFoundError struct {
+	Err error
+}
+
+func (e *NotFoundError) Error() string {
+	return "Not Found Error"
+}
+
+// InternalServerError 500:InternalServerエラー
+type InternalServerError struct {
+	Err error
+}
+
+func (e *InternalServerError) Error() string {
+	return "Internal Server Error"
+}

--- a/pkg/interfaces/api/server/server.go
+++ b/pkg/interfaces/api/server/server.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"layered-arch-sample/pkg/interfaces/api/myerror"
 	"log"
+	"net/http"
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
@@ -22,5 +24,50 @@ func Serve(addr string) {
 	log.Println("Server running...")
 	if err := e.Start(addr); err != nil {
 		log.Fatalf("Listen and serve failed. %+v", err)
+	}
+}
+
+func errorHandler(err error, c echo.Context) {
+	type response struct {
+		Message string `json:"message"`
+	}
+	var (
+		code    int
+		msg     string
+		errInfo error
+	)
+
+	switch e := err.(type) {
+	case *myerror.BadRequestError:
+		code = http.StatusBadRequest
+		msg = e.Message
+		errInfo = e.Err
+	case *myerror.UnauthorizedError:
+		code = http.StatusUnauthorized
+		msg = "401 認証エラー"
+		errInfo = e.Err
+	case *myerror.NotFoundError:
+		code = http.StatusNotFound
+		msg = "404 not found"
+		errInfo = e.Err
+	case *myerror.InternalServerError:
+		code = http.StatusInternalServerError
+		msg = "内部的なエラーが発生しました。リトライしてみてください。"
+		errInfo = e.Err
+	default:
+		code = http.StatusInternalServerError
+		msg = "エラーが発生しました。リトライしてみてください。"
+		errInfo = err
+	}
+
+	// Todo: 認証後はUserIDも表示
+	log.Printf(`access:"%s", errorCode:%d, errorMessage:"%s", error="%+v"`, c.Request().URL, code, msg, errInfo)
+
+	if !c.Response().Committed {
+		if err := c.JSON(code, &response{
+			Message: msg,
+		}); err != nil {
+			log.Print("errorResponseのJson変換エラー")
+		}
 	}
 }

--- a/pkg/usecase/user/usecase.go
+++ b/pkg/usecase/user/usecase.go
@@ -16,9 +16,9 @@ type useCase struct {
 }
 
 // NewUseCase Userデータに関するユースケースを生成
-func NewUseCase(ur ur.Repository) UseCase {
+func NewUseCase(userRepo ur.Repository) UseCase {
 	return &useCase{
-		repository: ur,
+		repository: userRepo,
 	}
 }
 

--- a/pkg/usecase/user/usecase.go
+++ b/pkg/usecase/user/usecase.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	ur "layered-arch-sample/pkg/domain/repository/db/user"
+
+	"github.com/google/uuid"
+)
+
+// UseCase Userにおけるユースケースのインターフェース
+type UseCase interface {
+	Create(name string) (authToken string, err error)
+}
+
+type useCase struct {
+	repository ur.Repository
+}
+
+// NewUseCase Userデータに関するユースケースを生成
+func NewUseCase(ur ur.Repository) UseCase {
+	return &useCase{
+		repository: ur,
+	}
+}
+
+// CreateUser Userを新規作成するためのユースケース
+func (uu useCase) Create(name string) (string, error) {
+	userID, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+	authToken, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	if err := uu.repository.Create(userID.String(), authToken.String(), name); err != nil {
+		return "", err
+	}
+
+	return authToken.String(), nil
+}


### PR DESCRIPTION
## 概要
- 独自エラー追加
- ユーザーのドメインモデル作成
- ユーザー作成処理追加
- 名前は2文字以上10文字以下

## エンドポイント
```curl "http://localhost:8080/signup" -d "name=karamaru"```

## 次やること
- 認証後はerrorログにUserID記載