### PR TITLE
User#getの実装

### DIFF
--- a/pkg/domain/model/user/model.go
+++ b/pkg/domain/model/user/model.go
@@ -3,6 +3,6 @@ package user
 // User Userを表すドメインモデル
 type User struct {
 	ID        string `json:"id"`
-	AuthToken string `json:"auth_token"`
+	AuthToken string `json:"auth_token,omitempty"`
 	Name      string `json:"name"`
 }

--- a/pkg/domain/repository/db/user/repository.go
+++ b/pkg/domain/repository/db/user/repository.go
@@ -1,6 +1,11 @@
 package user
 
+import (
+	"layered-arch-sample/pkg/domain/model/user"
+)
+
 // Repository データ永続化のために抽象化したUserデータ更新周りの処理
 type Repository interface {
 	Create(ID, authToken, name string) error
+	SelectByAuthToken(authToken string) (*user.User, error)
 }

--- a/pkg/infrastructure/mysql/repositoryimpl/user/repositoryimpl.go
+++ b/pkg/infrastructure/mysql/repositoryimpl/user/repositoryimpl.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"database/sql"
+	um "layered-arch-sample/pkg/domain/model/user"
 	ur "layered-arch-sample/pkg/domain/repository/db/user"
 )
 
@@ -25,4 +26,21 @@ func (uri repositoryImpl) Create(ID, authToken, name string) error {
 
 	_, err = stmt.Exec(ID, authToken, name)
 	return err
+}
+
+// SelectByAuthToken auth_tokenを条件にUserを取得する
+func (uri repositoryImpl) SelectByAuthToken(authToken string) (*um.User, error) {
+	row := uri.db.QueryRow("SELECT * FROM users WHERE auth_token = ?", authToken)
+	return convertToUser(row)
+}
+
+func convertToUser(row *sql.Row) (*um.User, error) {
+	user := um.User{}
+	if err := row.Scan(&user.ID, &user.AuthToken, &user.Name); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &user, nil
 }

--- a/pkg/interfaces/api/dcontext/dcontext.go
+++ b/pkg/interfaces/api/dcontext/dcontext.go
@@ -1,0 +1,25 @@
+package dcontext
+
+import (
+	um "layered-arch-sample/pkg/domain/model/user"
+
+	"github.com/labstack/echo"
+)
+
+var userKey = "userKey"
+
+// SetUser Contextへユーザを保存する
+func SetUser(c echo.Context, user um.User) {
+	c.Set(userKey, user)
+}
+
+// GetUserFromContext Contextからユーザを取得する
+func GetUserFromContext(c echo.Context) *um.User {
+	var user um.User
+	if c.Get(userKey) == nil {
+		return nil
+	}
+
+	user = c.Get(userKey).(um.User)
+	return &user
+}

--- a/pkg/interfaces/api/handler/user/handler.go
+++ b/pkg/interfaces/api/handler/user/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"layered-arch-sample/pkg/constant"
 	um "layered-arch-sample/pkg/domain/model/user"
+	"layered-arch-sample/pkg/interfaces/api/dcontext"
 	"layered-arch-sample/pkg/interfaces/api/myerror"
 	uu "layered-arch-sample/pkg/usecase/user"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 // Handler UserにおけるHandlerのインターフェース
 type Handler interface {
 	HandleCreate(c echo.Context) error
+	HandleGet(c echo.Context) error
 }
 
 type handler struct {
@@ -52,4 +54,18 @@ func (uh handler) HandleCreate(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, &response{Token: authToken})
+}
+
+// HandleGet ユーザー取得処理
+func (uh handler) HandleGet(c echo.Context) error {
+
+	user := dcontext.GetUserFromContext(c)
+	if user == nil {
+		return &myerror.UnauthorizedError{Err: errors.New("user not found")}
+	}
+
+	return c.JSON(http.StatusOK, &um.User{
+		ID:   user.ID,
+		Name: user.Name,
+	})
 }

--- a/pkg/interfaces/api/middleware/auth.go
+++ b/pkg/interfaces/api/middleware/auth.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"layered-arch-sample/pkg/interfaces/api/dcontext"
+	"layered-arch-sample/pkg/interfaces/api/myerror"
+	"layered-arch-sample/pkg/usecase/user"
+
+	"github.com/labstack/echo"
+	"github.com/pkg/errors"
+)
+
+// Middleware middlewareのインターフェース
+type Middleware interface {
+	Authenticate(echo.HandlerFunc) echo.HandlerFunc
+}
+
+type middleware struct {
+	useCase user.UseCase
+}
+
+// NewMiddleware userUseCaseと疎通
+func NewMiddleware(uu user.UseCase) Middleware {
+	return &middleware{
+		useCase: uu,
+	}
+}
+
+// Authenticate ユーザ認証を行ってContextへユーザID情報を保存する
+func (m middleware) Authenticate(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+
+		token := c.Request().Header.Get("x-token")
+		if token == "" {
+			return &myerror.UnauthorizedError{Err: errors.New("x-token is empty")}
+		}
+
+		user, err := m.useCase.SelectByAuthToken(token)
+		if err != nil {
+			return &myerror.InternalServerError{Err: err}
+		}
+		if user == nil {
+			return &myerror.UnauthorizedError{Err: errors.Errorf(`user is not found: token="%s"`, token)}
+		}
+
+		dcontext.SetUser(c, *user)
+
+		return next(c)
+	}
+}

--- a/pkg/interfaces/api/server/server.go
+++ b/pkg/interfaces/api/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"layered-arch-sample/pkg/infrastructure/mysql"
 	ur "layered-arch-sample/pkg/infrastructure/mysql/repositoryimpl/user"
+	"layered-arch-sample/pkg/interfaces/api/dcontext"
 	uh "layered-arch-sample/pkg/interfaces/api/handler/user"
 	"layered-arch-sample/pkg/interfaces/api/myerror"
 	uu "layered-arch-sample/pkg/usecase/user"
@@ -53,10 +54,15 @@ func errorHandler(err error, c echo.Context) {
 		Message string `json:"message"`
 	}
 	var (
+		userID  string
 		code    int
 		msg     string
 		errInfo error
 	)
+
+	if user := dcontext.GetUserFromContext(c); user != nil {
+		userID = user.ID
+	}
 
 	switch e := err.(type) {
 	case *myerror.BadRequestError:
@@ -81,8 +87,7 @@ func errorHandler(err error, c echo.Context) {
 		errInfo = err
 	}
 
-	// Todo: 認証後はUserIDも表示
-	log.Printf(`access:"%s", errorCode:%d, errorMessage:"%s", error="%+v"`, c.Request().URL, code, msg, errInfo)
+	log.Printf(`access:"%s", userID:"%s", errorCode:%d, errorMessage:"%s", error="%+v"`, c.Request().URL, userID, code, msg, errInfo)
 
 	if !c.Response().Committed {
 		if err := c.JSON(code, &response{

--- a/pkg/usecase/user/usecase.go
+++ b/pkg/usecase/user/usecase.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	um "layered-arch-sample/pkg/domain/model/user"
 	ur "layered-arch-sample/pkg/domain/repository/db/user"
 
 	"github.com/google/uuid"
@@ -9,6 +10,7 @@ import (
 // UseCase Userにおけるユースケースのインターフェース
 type UseCase interface {
 	Create(name string) (authToken string, err error)
+	SelectByAuthToken(authToken string) (user *um.User, err error)
 }
 
 type useCase struct {
@@ -38,4 +40,9 @@ func (uu useCase) Create(name string) (string, error) {
 	}
 
 	return authToken.String(), nil
+}
+
+// SelectByAuthToken Userをトークンから取得するためのユースケース
+func (uu useCase) SelectByAuthToken(authToken string) (*um.User, error) {
+	return uu.repository.SelectByAuthToken(authToken)
 }


### PR DESCRIPTION
## 概要
- ユーザー取得処理を追加

## エンドポイント
ex) tokenが```0ae7c8cf-50a6-4fac-8901-eedd29456c84"```のユーザーが自分のユーザー情報を取得
``` curl -X GET "http://localhost:8080/account" -H  "accept: application/json" -H  "x-token: 0ae7c8cf-50a6-4fac-8901-eedd29456c84"```