### PR TITLE
ユーザー更新処理を追加

### DIFF
--- a/pkg/domain/repository/db/user/repository.go
+++ b/pkg/domain/repository/db/user/repository.go
@@ -8,4 +8,5 @@ import (
 type Repository interface {
 	Create(ID, authToken, name string) error
 	SelectByAuthToken(authToken string) (*user.User, error)
+	UpdateName(user *user.User, name string) error
 }

--- a/pkg/infrastructure/mysql/repositoryimpl/user/repositoryimpl.go
+++ b/pkg/infrastructure/mysql/repositoryimpl/user/repositoryimpl.go
@@ -34,6 +34,16 @@ func (uri repositoryImpl) SelectByAuthToken(authToken string) (*um.User, error) 
 	return convertToUser(row)
 }
 
+// UpdateName ユーザーの名前を更新する
+func (uri repositoryImpl) UpdateName(record *um.User, name string) error {
+	stmt, err := uri.db.Prepare("UPDATE users SET name = ? WHERE id = ?")
+	if err != nil {
+		return err
+	}
+	_, err = stmt.Exec(name, record.ID)
+	return err
+}
+
 func convertToUser(row *sql.Row) (*um.User, error) {
 	user := um.User{}
 	if err := row.Scan(&user.ID, &user.AuthToken, &user.Name); err != nil {

--- a/pkg/interfaces/api/server/server.go
+++ b/pkg/interfaces/api/server/server.go
@@ -6,12 +6,11 @@ import (
 	ur "layered-arch-sample/pkg/infrastructure/mysql/repositoryimpl/user"
 	"layered-arch-sample/pkg/interfaces/api/dcontext"
 	uh "layered-arch-sample/pkg/interfaces/api/handler/user"
+	authMiddleware "layered-arch-sample/pkg/interfaces/api/middleware"
 	"layered-arch-sample/pkg/interfaces/api/myerror"
 	uu "layered-arch-sample/pkg/usecase/user"
 	"log"
 	"net/http"
-
-	authMiddleware "layered-arch-sample/pkg/interfaces/api/middleware"
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
@@ -42,6 +41,7 @@ func Serve(addr string) {
 
 	e.POST("/signup", userHandler.HandleCreate)
 	e.GET("/account", auth.Authenticate(userHandler.HandleGet))
+	e.PATCH("/account", auth.Authenticate(userHandler.HandleUpdate))
 
 	log.Println("Server running...")
 	if err := e.Start(addr); err != nil {

--- a/pkg/usecase/user/usecase.go
+++ b/pkg/usecase/user/usecase.go
@@ -11,6 +11,7 @@ import (
 type UseCase interface {
 	Create(name string) (authToken string, err error)
 	SelectByAuthToken(authToken string) (user *um.User, err error)
+	UpdateName(user *um.User, name string) error
 }
 
 type useCase struct {
@@ -45,4 +46,8 @@ func (uu useCase) Create(name string) (string, error) {
 // SelectByAuthToken Userをトークンから取得するためのユースケース
 func (uu useCase) SelectByAuthToken(authToken string) (*um.User, error) {
 	return uu.repository.SelectByAuthToken(authToken)
+}
+
+func (uu useCase) UpdateName(user *um.User, name string) error {
+	return uu.repository.UpdateName(user, name)
 }


### PR DESCRIPTION
## 概要
- 自分の名前を更新するAPI追加
- 2<=x<=10文字のバリデーションは健在

## エンドポイント
ex) tokenが```0ae7c8cf-50a6-4fac-8901-eedd29456c84```のユーザーが自分の名前を「karamaroon」に更新
```curl -X PATCH "http://localhost:8080/account" -d "name=karamaroon" -H "accept: application/json" -H "x-token: 0ae7c8cf-50a6-4fac-8901-eedd29456c84"```